### PR TITLE
Remove k8s version 1.24 from e2e test matrix

### DIFF
--- a/.github/workflows/e2e-tests-ondemand.yaml
+++ b/.github/workflows/e2e-tests-ondemand.yaml
@@ -26,8 +26,6 @@ jobs:
       max-parallel: 4
       matrix:
         include:
-          - version: 1-24
-            platform: k8s
           - version: 1-25
             platform: k8s
           - version: 1-26


### PR DESCRIPTION
## Description

Kubernetes version 1.24 is EOL according to Dynatrace docs at https://docs.dynatrace.com/docs/whats-new/technology/end-of-support-news#dto and can thus be removed from the matrix of tested versions.

## How can this be tested?

E2E tests will not be executed for k8s 1.24.